### PR TITLE
Add options available in FFI::CheckLib v0.28

### DIFF
--- a/lib/Dist/Zilla/Plugin/FFI/CheckLib.pm
+++ b/lib/Dist/Zilla/Plugin/FFI/CheckLib.pm
@@ -16,6 +16,7 @@ package Dist::Zilla::Plugin::FFI::CheckLib {
   use namespace::autoclean;
 
   my @list_options = qw/
+    alien
     lib
     libpath
     symbol
@@ -32,7 +33,7 @@ package Dist::Zilla::Plugin::FFI::CheckLib {
     handles => { $_ => 'elements' },
   ) for @list_options;
 
-  has recursive => (
+  has [ qw/recursive try_linker_script/ ] => (
     is      => 'rw',
     lazy    => 1,
     default => sub { 0 },
@@ -45,6 +46,7 @@ package Dist::Zilla::Plugin::FFI::CheckLib {
     $config->{+__PACKAGE__} = +{
       (map {; $_ => [ $self->$_ ] } @list_options),
       recursive => $self->recursive,
+      try_linker_script => $self->try_linker_script,
     };
 
     $config
@@ -56,7 +58,7 @@ package Dist::Zilla::Plugin::FFI::CheckLib {
         phase => 'configure',
         type  => 'requires',
       },
-      'FFI::CheckLib' => '0.11',
+      'FFI::CheckLib' => '0.28',
     );
   }
 
@@ -115,7 +117,9 @@ package Dist::Zilla::Plugin::FFI::CheckLib {
         [
           $_ => @stuff > 1 ? ('[ ' . join(', ', @stuff) . ' ]') : $stuff[0]
         ] : ()
-    } grep !/^verify$/, @list_options, ( $self->recursive ? 'recursive' : () );
+    } grep !/^verify$/, @list_options,
+        ( $self->recursive ? 'recursive' : () ),
+        ( $self->try_linker_script ? 'try_linker_script' : () );
 
     my @verify = map { s/^\|//r } $self->verify;
 
@@ -181,10 +185,24 @@ paths). Can be used more than once.
 
 Additional path to search for libraries. Can be used more than once.
 
+=head2 C<alien>
+
+The name of an L<Alien> class that provides the L<Alien::Base> interface for
+dynamic libraries.
+
+Can be used more than once.
+
 =head2 C<recursive>
 
 If set to true, directories specified in C<libpath> will be searched
 recursively.
+
+Defaults to false.
+
+=head2 C<try_linker_script>
+
+If set to true, uses the linker command to attempt to resolve C<.so> files for
+platforms where C<.so> files are linker scripts.
 
 Defaults to false.
 

--- a/t/dist_zilla_plugin_ffi_checklib.t
+++ b/t/dist_zilla_plugin_ffi_checklib.t
@@ -18,11 +18,13 @@ use warnings;
 # inserted by Dist::Zilla::Plugin::FFI::CheckLib @{[ Dist::Zilla::Plugin::FFI::CheckLib->VERSION || '<self>' ]}
 use FFI::CheckLib;
 check_lib_or_exit(
+  alien => [ 'Alien::iconv', 'Alien::jpeg' ],
   lib => [ 'iconv', 'jpeg' ],
   libpath => 'additional_path',
   symbol => [ 'foo', 'bar' ],
   systempath => 'system',
   recursive => '1',
+  try_linker_script => '1',
   verify => sub {
     my(\$name, \$libpath) = \@_;
     1;
@@ -55,7 +57,9 @@ foreach my $test (@tests)
                             libpath => 'additional_path',
                             symbol => [ qw(foo bar) ],
                             systempath => 'system',
+                            alien => [ qw(Alien::iconv Alien::jpeg) ],
                             recursive => 1,
+                            try_linker_script => 1,
                             verify => [
                               '|my($name, $libpath) = @_;',
                               '|1;',
@@ -91,7 +95,7 @@ foreach my $test (@tests)
 
     is(
         $tzil->distmeta->{prereqs}->{configure}->{requires}->{'FFI::CheckLib'},
-        '0.11',
+        '0.28',
     );
 
     #diag 'got log messages: ', explain $tzil->log_messages


### PR DESCRIPTION
These options are:
  - `alien`
  - `try_linker_script`
and require bumping the version of FFI::CheckLib in the requirements.
