### PR TITLE
handle whitespace changes in [ModuleBuildTiny]

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Handle whitespace changes in [ModuleBuildTiny] (gh#12, gh#13)
 
 1.07      2022-10-16 04:37:01 -0600
   - Removed mostly harmless warning (gh#10)

--- a/lib/Dist/Zilla/Plugin/FFI/CheckLib.pm
+++ b/lib/Dist/Zilla/Plugin/FFI/CheckLib.pm
@@ -108,7 +108,7 @@ package Dist::Zilla::Plugin::FFI::CheckLib {
 
     my $orig_content = $file->content;
     $self->log_fatal('could not find position in ' . $file->name . ' to modify!')
-      unless $orig_content =~ m/use strict;\nuse warnings;\n\n/g;
+      unless $orig_content =~ m/use strict;\nuse warnings;\n\n?/g;
     my $pos = pos($orig_content);
 
     my @options = map {;

--- a/t/dist_zilla_plugin_ffi_checklib.t
+++ b/t/dist_zilla_plugin_ffi_checklib.t
@@ -12,9 +12,6 @@ my @tests = (
 );
 
 my $pattern = <<PATTERN;
-use strict;
-use warnings;
-
 # inserted by Dist::Zilla::Plugin::FFI::CheckLib @{[ Dist::Zilla::Plugin::FFI::CheckLib->VERSION || '<self>' ]}
 use FFI::CheckLib;
 check_lib_or_exit(


### PR DESCRIPTION
This adjusts the regex and tests for `[FFI::CheckLib]` such that it works with recent `[ModuleBuildTiny]` output.  Other alternatives include

1. Adjust `[ModuleBuildTiny]` to put the extra blank line in, advantage here is no other plugins that expect this output need to be changed (`[CheckLib]`, on which `[FFI::CheckLib]` is based is also has the same challenge and there may be more).
2. Create a role presumably in `Dist-Zilla` core that offloads this work to simplify plugins that need to make this sort of change.  advantage is this will likely be less brittle, disadvantage is that there are more dists that need modification.